### PR TITLE
[AI Worker] Implement todo CRUD application with Vue 3 components

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,18 +1,166 @@
 <script setup>
+import { computed } from 'vue'
+import AppToast from './components/AppToast.vue'
+import TodoForm from './components/TodoForm.vue'
+import TodoList from './components/TodoList.vue'
+import { useToast } from './composables/useToast'
+import { useTodoStore } from './stores/useTodoStore'
+
+const { todos, editingId, addTodo, updateTodo, deleteTodo, startEditing, resetEditing } = useTodoStore()
+const { toasts, showSuccess, showError, removeToast } = useToast()
+
+const currentTodo = computed(() => {
+  return todos.value.find((todo) => todo.id === editingId.value) ?? null
+})
+
+const isEditing = computed(() => editingId.value !== null)
+
+const formValues = computed(() => {
+  return currentTodo.value
+    ? {
+        title: currentTodo.value.title,
+        description: currentTodo.value.description,
+      }
+    : {
+        title: '',
+        description: '',
+      }
+})
+
+function handleSubmitTodo(payload) {
+  if (!payload.title.trim()) {
+    showError('Title is required.')
+    return
+  }
+
+  if (isEditing.value) {
+    const updated = updateTodo(editingId.value, payload)
+
+    if (!updated) {
+      showError('Unable to update that todo.')
+      return
+    }
+
+    resetEditing()
+    showSuccess('Todo updated.')
+    return
+  }
+
+  const added = addTodo(payload)
+
+  if (!added) {
+    showError('Unable to add that todo.')
+    return
+  }
+
+  showSuccess('Todo added.')
+}
+
+function handleEditTodo(todo) {
+  startEditing(todo.id)
+}
+
+function handleDeleteTodo(id) {
+  const deleted = deleteTodo(id)
+
+  if (!deleted) {
+    showError('Unable to delete that todo.')
+    return
+  }
+
+  showSuccess('Todo deleted.')
+}
+
+function handleCancelEdit() {
+  resetEditing()
+}
 </script>
 
 <template>
   <div id="app">
-    <h1>Vue CRUD Demo</h1>
-    <p>App placeholder — features will be added via issues.</p>
+    <header class="app-shell__header">
+      <p class="app-shell__eyebrow">Vue 3 CRUD Demo</p>
+      <h1 class="app-shell__title">Keep your tasks clear, current, and local.</h1>
+      <p class="app-shell__subtitle">
+        Create, edit, and remove todos with local persistence and lightweight notifications.
+      </p>
+    </header>
+
+    <main class="app-shell__content">
+      <TodoForm
+        :initial-values="formValues"
+        :is-editing="isEditing"
+        @submit-todo="handleSubmitTodo"
+        @cancel-edit="handleCancelEdit"
+      />
+      <TodoList :todos="todos" @edit-todo="handleEditTodo" @delete-todo="handleDeleteTodo" />
+    </main>
+
+    <AppToast :toasts="toasts" @dismiss-toast="removeToast" />
   </div>
 </template>
 
 <style scoped>
 #app {
-  max-width: 800px;
+  width: min(960px, calc(100vw - 2rem));
   margin: 0 auto;
+  padding: 4rem 0 3rem;
+}
+
+#app::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background:
+    radial-gradient(circle at top left, rgba(74, 144, 217, 0.2), transparent 34%),
+    radial-gradient(circle at bottom right, rgba(39, 174, 96, 0.14), transparent 28%);
+}
+
+.app-shell__header {
+  margin-bottom: 2rem;
   padding: 2rem;
-  font-family: Inter, system-ui, sans-serif;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(255, 255, 255, 0.78));
+  border: 1px solid rgba(220, 223, 230, 0.9);
+  border-radius: calc(var(--radius) * 1.5);
+  box-shadow: 0 22px 45px rgba(44, 62, 80, 0.08);
+}
+
+.app-shell__eyebrow {
+  margin-bottom: var(--spacing-sm);
+  color: var(--color-primary);
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.app-shell__title {
+  max-width: 12ch;
+  font-size: clamp(2.4rem, 5vw, 4.2rem);
+  line-height: 0.95;
+}
+
+.app-shell__subtitle {
+  max-width: 42rem;
+  margin-top: var(--spacing-md);
+  color: var(--color-text-muted);
+  font-size: 1.05rem;
+}
+
+.app-shell__content {
+  display: grid;
+  gap: var(--spacing-lg);
+}
+
+@media (max-width: 640px) {
+  #app {
+    width: min(100vw - 1rem, 960px);
+    padding-top: 1rem;
+  }
+
+  .app-shell__header {
+    padding: var(--spacing-lg);
+  }
 }
 </style>

--- a/src/components/AppToast.vue
+++ b/src/components/AppToast.vue
@@ -1,0 +1,86 @@
+<script setup>
+const props = defineProps({
+  toasts: {
+    type: Array,
+    required: true,
+  },
+})
+
+const emit = defineEmits(['dismiss-toast'])
+
+function handleDismiss(id) {
+  emit('dismiss-toast', id)
+}
+</script>
+
+<template>
+  <div class="app-toast" aria-live="polite" aria-atomic="true">
+    <article
+      v-for="toast in props.toasts"
+      :key="toast.id"
+      class="app-toast__item"
+      :class="`app-toast__item--${toast.variant}`"
+    >
+      <p class="app-toast__message">{{ toast.message }}</p>
+      <button class="app-toast__dismiss" type="button" @click="handleDismiss(toast.id)">
+        Dismiss
+      </button>
+    </article>
+  </div>
+</template>
+
+<style scoped>
+.app-toast {
+  position: fixed;
+  top: var(--spacing-lg);
+  right: var(--spacing-lg);
+  z-index: 20;
+  display: grid;
+  gap: var(--spacing-sm);
+  width: min(22rem, calc(100vw - 2rem));
+}
+
+.app-toast__item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--spacing-sm);
+  align-items: center;
+  padding: 0.9rem 1rem;
+  color: #ffffff;
+  border-radius: var(--radius);
+  box-shadow: 0 14px 30px rgba(44, 62, 80, 0.18);
+}
+
+.app-toast__item--success {
+  background: var(--color-success);
+}
+
+.app-toast__item--error {
+  background: var(--color-danger);
+}
+
+.app-toast__message {
+  line-height: 1.4;
+}
+
+.app-toast__dismiss {
+  color: inherit;
+  background: transparent;
+  border: none;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  opacity: 0.85;
+}
+
+@media (max-width: 640px) {
+  .app-toast {
+    top: var(--spacing-md);
+    right: var(--spacing-md);
+  }
+
+  .app-toast__item {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/components/TodoForm.vue
+++ b/src/components/TodoForm.vue
@@ -1,0 +1,199 @@
+<script setup>
+import { reactive, watch } from 'vue'
+
+const props = defineProps({
+  initialValues: {
+    type: Object,
+    required: true,
+  },
+  isEditing: {
+    type: Boolean,
+    required: true,
+  },
+})
+
+const emit = defineEmits(['submit-todo', 'cancel-edit'])
+
+const form = reactive({
+  title: '',
+  description: '',
+})
+
+watch(
+  () => props.initialValues,
+  (values) => {
+    form.title = values.title ?? ''
+    form.description = values.description ?? ''
+  },
+  { immediate: true }
+)
+
+function handleSubmit() {
+  const title = form.title.trim()
+
+  if (!title) {
+    return
+  }
+
+  emit('submit-todo', {
+    title,
+    description: form.description.trim(),
+  })
+
+  if (!props.isEditing) {
+    form.title = ''
+    form.description = ''
+  }
+}
+
+function handleCancel() {
+  form.title = props.initialValues.title ?? ''
+  form.description = props.initialValues.description ?? ''
+  emit('cancel-edit')
+}
+</script>
+
+<template>
+  <form
+    class="todo-form"
+    :class="{ 'todo-form--editing': isEditing }"
+    @submit.prevent="handleSubmit"
+  >
+    <div class="todo-form__field">
+      <label class="todo-form__label" for="todo-title">Title</label>
+      <input
+        id="todo-title"
+        v-model="form.title"
+        class="todo-form__input"
+        type="text"
+        name="title"
+        placeholder="What needs to get done?"
+        required
+      />
+    </div>
+
+    <div class="todo-form__field">
+      <label class="todo-form__label" for="todo-description">Description</label>
+      <textarea
+        id="todo-description"
+        v-model="form.description"
+        class="todo-form__textarea"
+        name="description"
+        rows="4"
+        placeholder="Add more context for this task"
+      />
+    </div>
+
+    <div class="todo-form__actions">
+      <button class="todo-form__button todo-form__button--primary" type="submit">
+        {{ isEditing ? 'Update' : 'Add' }}
+      </button>
+      <button
+        v-if="isEditing"
+        class="todo-form__button todo-form__button--secondary"
+        type="button"
+        @click="handleCancel"
+      >
+        Cancel
+      </button>
+    </div>
+  </form>
+</template>
+
+<style scoped>
+.todo-form {
+  display: grid;
+  gap: var(--spacing-md);
+  padding: var(--spacing-lg);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  box-shadow: 0 18px 40px rgba(44, 62, 80, 0.08);
+}
+
+.todo-form--editing {
+  border-color: var(--color-primary);
+}
+
+.todo-form__field {
+  display: grid;
+  gap: var(--spacing-sm);
+}
+
+.todo-form__label {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.todo-form__input,
+.todo-form__textarea {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: calc(var(--radius) - 2px);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.todo-form__input:focus,
+.todo-form__textarea:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(74, 144, 217, 0.18);
+}
+
+.todo-form__textarea {
+  resize: vertical;
+  min-height: 7rem;
+}
+
+.todo-form__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+}
+
+.todo-form__button {
+  border: none;
+  border-radius: calc(var(--radius) - 2px);
+  padding: 0.8rem 1.25rem;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.todo-form__button:hover {
+  transform: translateY(-1px);
+}
+
+.todo-form__button--primary {
+  color: #ffffff;
+  background: var(--color-primary);
+}
+
+.todo-form__button--primary:hover {
+  background: var(--color-primary-hover);
+}
+
+.todo-form__button--secondary {
+  color: var(--color-text);
+  background: transparent;
+  border: 1px solid var(--color-border);
+}
+
+@media (max-width: 640px) {
+  .todo-form {
+    padding: var(--spacing-md);
+  }
+
+  .todo-form__actions {
+    flex-direction: column;
+  }
+
+  .todo-form__button {
+    width: 100%;
+  }
+}
+</style>

--- a/src/components/TodoItem.vue
+++ b/src/components/TodoItem.vue
@@ -1,0 +1,129 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  todo: {
+    type: Object,
+    required: true,
+  },
+})
+
+const emit = defineEmits(['edit-todo', 'delete-todo'])
+
+const formattedCreatedAt = computed(() => {
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(props.todo.createdAt))
+})
+
+function handleEdit() {
+  emit('edit-todo', props.todo)
+}
+
+function handleDelete() {
+  emit('delete-todo', props.todo.id)
+}
+</script>
+
+<template>
+  <article class="todo-item">
+    <div class="todo-item__content">
+      <p class="todo-item__meta">Created {{ formattedCreatedAt }}</p>
+      <h3 class="todo-item__title">{{ todo.title }}</h3>
+      <p v-if="todo.description" class="todo-item__description">
+        {{ todo.description }}
+      </p>
+    </div>
+
+    <div class="todo-item__actions">
+      <button class="todo-item__button todo-item__button--edit" type="button" @click="handleEdit">
+        Edit
+      </button>
+      <button
+        class="todo-item__button todo-item__button--delete"
+        type="button"
+        @click="handleDelete"
+      >
+        Delete
+      </button>
+    </div>
+  </article>
+</template>
+
+<style scoped>
+.todo-item {
+  display: grid;
+  gap: var(--spacing-md);
+  padding: var(--spacing-lg);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  box-shadow: 0 16px 32px rgba(44, 62, 80, 0.06);
+}
+
+.todo-item__content {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.todo-item__meta {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.todo-item__title {
+  font-size: 1.1rem;
+  line-height: 1.3;
+}
+
+.todo-item__description {
+  color: var(--color-text-muted);
+}
+
+.todo-item__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+}
+
+.todo-item__button {
+  border: none;
+  border-radius: calc(var(--radius) - 2px);
+  padding: 0.7rem 1rem;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.todo-item__button--edit {
+  color: #ffffff;
+  background: var(--color-primary);
+}
+
+.todo-item__button--edit:hover {
+  background: var(--color-primary-hover);
+}
+
+.todo-item__button--delete {
+  color: #ffffff;
+  background: var(--color-danger);
+}
+
+.todo-item__button--delete:hover {
+  background: var(--color-danger-hover);
+}
+
+@media (min-width: 720px) {
+  .todo-item {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+  }
+
+  .todo-item__actions {
+    justify-content: flex-end;
+  }
+}
+</style>

--- a/src/components/TodoList.vue
+++ b/src/components/TodoList.vue
@@ -1,0 +1,55 @@
+<script setup>
+import TodoItem from './TodoItem.vue'
+
+const props = defineProps({
+  todos: {
+    type: Array,
+    required: true,
+  },
+})
+
+const emit = defineEmits(['edit-todo', 'delete-todo'])
+
+function handleEditTodo(todo) {
+  emit('edit-todo', todo)
+}
+
+function handleDeleteTodo(id) {
+  emit('delete-todo', id)
+}
+</script>
+
+<template>
+  <section class="todo-list">
+    <p v-if="!props.todos.length" class="todo-list__empty">No todos yet. Add your first task.</p>
+    <div v-else class="todo-list__items">
+      <TodoItem
+        v-for="todo in props.todos"
+        :key="todo.id"
+        :todo="todo"
+        @edit-todo="handleEditTodo"
+        @delete-todo="handleDeleteTodo"
+      />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.todo-list {
+  min-height: 12rem;
+}
+
+.todo-list__items {
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.todo-list__empty {
+  padding: calc(var(--spacing-lg) * 1.25);
+  color: var(--color-text-muted);
+  text-align: center;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius);
+}
+</style>

--- a/src/composables/useToast.js
+++ b/src/composables/useToast.js
@@ -1,0 +1,42 @@
+import { reactive, toRefs } from 'vue'
+
+const TOAST_DURATION = 3000
+
+const state = reactive({
+  toasts: [],
+})
+
+function removeToast(id) {
+  state.toasts = state.toasts.filter((toast) => toast.id !== id)
+}
+
+function enqueueToast(message, variant) {
+  const toast = {
+    id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    message,
+    variant,
+  }
+
+  state.toasts.push(toast)
+
+  setTimeout(() => {
+    removeToast(toast.id)
+  }, TOAST_DURATION)
+}
+
+function showSuccess(message) {
+  enqueueToast(message, 'success')
+}
+
+function showError(message) {
+  enqueueToast(message, 'error')
+}
+
+export function useToast() {
+  return {
+    ...toRefs(state),
+    showSuccess,
+    showError,
+    removeToast,
+  }
+}

--- a/src/stores/useTodoStore.js
+++ b/src/stores/useTodoStore.js
@@ -1,0 +1,115 @@
+import { reactive, toRefs } from 'vue'
+
+const STORAGE_KEY = 'vue-crud-todos'
+
+const state = reactive({
+  todos: [],
+  editingId: null,
+})
+
+function loadFromStorage() {
+  if (typeof localStorage === 'undefined') {
+    state.todos = []
+    return
+  }
+
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    state.todos = raw ? JSON.parse(raw) : []
+  } catch {
+    state.todos = []
+  }
+}
+
+function saveToStorage() {
+  if (typeof localStorage === 'undefined') {
+    return
+  }
+
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state.todos))
+}
+
+function generateTodoId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+
+  return String(Date.now())
+}
+
+function addTodo(payload) {
+  const title = payload.title.trim()
+
+  if (!title) {
+    return false
+  }
+
+  state.todos.unshift({
+    id: generateTodoId(),
+    title,
+    description: payload.description.trim(),
+    createdAt: new Date().toISOString(),
+  })
+  saveToStorage()
+  return true
+}
+
+function updateTodo(id, payload) {
+  const title = payload.title.trim()
+
+  if (!title) {
+    return false
+  }
+
+  const todoIndex = state.todos.findIndex((todo) => todo.id === id)
+
+  if (todoIndex === -1) {
+    return false
+  }
+
+  state.todos[todoIndex] = {
+    ...state.todos[todoIndex],
+    title,
+    description: payload.description.trim(),
+  }
+  saveToStorage()
+  return true
+}
+
+function deleteTodo(id) {
+  const nextTodos = state.todos.filter((todo) => todo.id !== id)
+
+  if (nextTodos.length === state.todos.length) {
+    return false
+  }
+
+  state.todos = nextTodos
+
+  if (state.editingId === id) {
+    state.editingId = null
+  }
+
+  saveToStorage()
+  return true
+}
+
+function startEditing(id) {
+  state.editingId = id
+}
+
+function resetEditing() {
+  state.editingId = null
+}
+
+loadFromStorage()
+
+export function useTodoStore() {
+  return {
+    ...toRefs(state),
+    addTodo,
+    updateTodo,
+    deleteTodo,
+    startEditing,
+    resetEditing,
+  }
+}


### PR DESCRIPTION
## Summary

This PR was generated automatically by AI Worker for issue #1.

### Plan

## AI Worker Plan

**Issue:** #1 — Implement todo CRUD application with Vue 3 components

### Understanding
This issue replaces the current placeholder app with a full Vue 3 Composition API todo CRUD flow: create, edit, delete, localStorage persistence, and stacked toast notifications. The implementation needs to follow the repo’s documented patterns exactly: `<script setup>`, module-level reactive store state, `toRefs()`, scoped styles, and CSS variables from [`src/style.css`](/Users/huahua/autotask/vue-crud-demo/src/style.css).

### Proposed Steps
1. Create [`src/stores/useTodoStore.js`](/Users/huahua/autotask/vue-crud-demo/src/stores/useTodoStore.js) with `export function useTodoStore()`, plus module-level helpers `function loadFromStorage()`, `function saveToStorage()`, `function generateTodoId()`, `function addTodo(payload)`, `function updateTodo(id, payload)`, `function deleteTodo(id)`, `function startEditing(id)`, and `function resetEditing()`. Follow the exact pattern from [`docs/store-pattern.md`](/Users/huahua/autotask/vue-crud-demo/docs/store-pattern.md): `const state = reactive({ todos: [], editingId: null })`, `const STORAGE_KEY = 'vue-crud-todos'`, `toRefs(state)` in the return value, todo shape `{ id, title, description, createdAt }`, `crypto.randomUUID()` with a `Date.now()` fallback, and `saveToStorage()` immediately after every `state.todos` mutation.

2. Create [`src/composables/useToast.js`](/Users/huahua/autotask/vue-crud-demo/src/composables/useToast.js) as a singleton-style composable with module-level reactive state, matching the shared-state approach used by the store docs. Add `export function useToast()`, `function showSuccess(message)`, `function showError(message)`, `function removeToast(id)`, and an internal `function enqueueToast(message, variant)`; store items as `{ id, message, variant }`, set auto-dismiss to `3000` ms with `setTimeout`, and return `toRefs(state)` so `toasts` remains reactive when destructured in [`src/App.vue`](/Users/huahua/autotask/vue-crud-demo/src/App.vue).

3. Create [`src/components/TodoForm.vue`](/Users/huahua/autotask/vue-crud-demo/src/components/TodoForm.vue) using the ordering required by [`docs/conventions.md`](/Users/huahua/autotask/vue-crud-demo/docs/conventions.md). Define props with `const props = defineProps({ initialValues: { type: Object, required: true }, isEditing: { type: Boolean, required: true } })`, emits with `const emit = defineEmits(['submit-todo', 'cancel-edit'])`, and methods `function handleSubmit()` and `function handleCancel()`. Use `v-model` on a required title field and optional description textarea, show `"Add"` when `isEditing === false` and `"Update"` when `true`, conditionally render the cancel button with `v-if`, and use scoped BEM-style classes such as `.todo-form`, `.todo-form__field`, and `.todo-form--editing` with colors/spacing from [`src/style.css`](/Users/huahua/autotask/vue-crud-demo/src/style.css).

4. Create [`src/components/TodoItem.vue`](/Users/huahua/autotask/vue-crud-demo/src/components/TodoItem.vue) with `const props = defineProps({ todo: { type: Object, required: true } })`, `const emit = defineEmits(['edit-todo', 'delete-todo'])`, a computed `const formattedCreatedAt = computed(() => ...)`, and methods `function handleEdit()` / `function handleDelete()`. Follow the prop/event example from [`docs/conventions.md`](/Users/huahua/autotask/vue-crud-demo/docs/conventions.md), display `todo.title`, `todo.description`, and a formatted `todo.createdAt`, hide or collapse the description block when it is empty, and wire the buttons to emit the full todo for edit and the `todo.id` for delete.

5. Create [`src/components/TodoList.vue`](/Users/huahua/autotask/vue-crud-demo/src/components/TodoList.vue) with `const props = defineProps({ todos: { type: Array, required: true } })`, `const emit = defineEmits(['edit-todo', 'delete-todo'])`, and pass-through handlers `function handleEditTodo(todo)` / `function handleDeleteTodo(id)`. Use the repo convention `v-for` with `:key="todo.id"` to render `TodoItem`, add an explicit empty state branch with `v-if="!todos.length"` and a concrete message such as `"No todos yet. Add your first task."`, and keep class names in BEM form like `.todo-list` and `.todo-list__empty`.

6. Create [`src/components/AppToast.vue`](/Users/huahua/autotask/vue-crud-demo/src/components/AppToast.vue) with `const props = defineProps({ toasts: { type: Array, required: true } })`, `const emit = defineEmits(['dismiss-toast'])`, and `function handleDismiss(id)`. Render a stacked list keyed by `toast.id`, apply success/error modifier classes such as `.app-toast__item--success` and `.app-toast__item--error` using `var(--color-success)` and `var(--color-danger)` from [`src/style.css`](/Users/huahua/autotask/vue-crud-demo/src/style.css), and expose a manual dismiss button even though `useToast()` auto-removes after `3000` ms.

7. Replace the placeholder in [`src/App.vue`](/Users/huahua/autotask/vue-crud-demo/src/App.vue) with `<script setup>` imports for `TodoForm`, `TodoList`, `AppToast`, `useTodoStore`, and `useToast`, keeping [`src/main.js`](/Users/huahua/autotask/vue-crud-demo/src/main.js) unchanged per [`agent.md`](/Users/huahua/autotask/vue-crud-demo/agent.md). Add app-level methods `function handleSubmitTodo(payload)`, `function handleEditTodo(todo)`, `function handleDeleteTodo(id)`, and `function handleCancelEdit()`; use the store’s `editingId` to derive `const currentTodo = computed(() => ...)` and `const isEditing = computed(() => editingId.value !== null)`, call `showSuccess()` for add/update/delete success cases, call `showError()` for invalid or failed operations, and keep scoped layout styles on `#app` using the existing CSS-variable palette rather than the current hardcoded placeholder typography.

8. Verify the full flow against the issue requirements with concrete cases before build: add a todo with title only, add one with title + description, edit an existing todo and confirm the form switches to `"Update"` plus cancel button, delete a todo, refresh the page to confirm localStorage reload through `loadFromStorage()`, and confirm multiple rapid `showSuccess()` calls stack in [`AppToast.vue`](/Users/huahua/autotask/vue-crud-demo/src/components/AppToast.vue). Finish by running `npm run build` and fix any Vue compile/style-scope issues that violate the `<script setup>` and `<style scoped>` constraints.

### Risks / Notes
- `localStorage` access happens at module init in the documented pattern; if Vite build or non-browser execution touches that code, the implementation should guard with `typeof localStorage !== 'undefined'` to avoid runtime errors.
- `updateTodo(id, payload)` should preserve the original `createdAt` value rather than regenerating it, otherwise the item’s displayed creation date will change unexpectedly.
- `TodoForm.vue` should trim the title before submit; otherwise whitespace-only titles can pass the HTML `required` check but still create invalid todos.

---
Reply with one of:
- `approve` — proceed with execution
- `skip` — ignore this issue
- `revise: <feedback>` — revise the plan with your feedback

### Codex Output (stdout)

```
Implemented the full Vue 3 todo CRUD flow with shared reactive state, localStorage persistence, edit mode, and stacked toast notifications. The main wiring is in [src/App.vue](/Users/huahua/autotask/vue-crud-demo/src/App.vue), with the singleton store in [src/stores/useTodoStore.js](/Users/huahua/autotask/vue-crud-demo/src/stores/useTodoStore.js) and toast composable in [src/composables/useToast.js](/Users/huahua/autotask/vue-crud-demo/src/composables/useToast.js). The UI pieces are split into [src/components/TodoForm.vue](/Users/huahua/autotask/vue-crud-demo/src/components/TodoForm.vue), [src/components/TodoList.vue](/Users/huahua/autotask/vue-crud-demo/src/components/TodoList.vue), [src/components/TodoItem.vue](/Users/huahua/autotask/vue-crud-demo/src/components/TodoItem.vue), and [src/components/AppToast.vue](/Users/huahua/autotask/vue-crud-demo/src/components/AppToast.vue).

`npm run build` passes. I verified the integration statically through the build and import graph; I did not run an interactive browser session in this turn.

```

Closes #1
