### PR TITLE
[AI Worker] Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,12 @@
     <title>vue-crud-demo</title>
   </head>
   <body>
+    <script>
+      (function () {
+        var t = localStorage.getItem('vue-crud-theme');
+        if (t === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
+      })();
+    </script>
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,9 +4,11 @@ import { RouterLink, RouterView, useRoute } from 'vue-router'
 
 import AppToast from './components/AppToast.vue'
 import { useToast } from './composables/useToast'
+import { useTheme } from './composables/useTheme'
 
 const route = useRoute()
 const { toasts, removeToast } = useToast()
+const { theme, toggleTheme } = useTheme()
 
 const navigationItems: Array<{ to: string; label: string; routeName: string; description: string }> = [
   {
@@ -73,6 +75,14 @@ function isActivePath(currentPath: string, targetPath: string, currentRouteName?
           <p class="app-shell__hero-label">当前页面</p>
           <p class="app-shell__hero-value">{{ currentPage.label }}</p>
           <p class="app-shell__hero-description">{{ currentPage.description }}</p>
+          <button
+            class="app-shell__theme-toggle"
+            type="button"
+            :aria-label="theme === 'light' ? '切换到深色模式' : '切换到浅色模式'"
+            @click="toggleTheme"
+          >
+            {{ theme === 'light' ? '深色模式' : '浅色模式' }}
+          </button>
         </div>
       </header>
 
@@ -99,4 +109,24 @@ function isActivePath(currentPath: string, targetPath: string, currentRouteName?
 </template>
 
 <style scoped>
+.app-shell__theme-toggle {
+  justify-self: start;
+  min-height: 40px;
+  padding: 0.5rem 1rem;
+  color: var(--color-primary);
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  font-weight: 600;
+  font-size: 0.88rem;
+  transition:
+    background-color 180ms ease,
+    border-color 180ms ease;
+}
+
+.app-shell__theme-toggle:hover {
+  border-color: var(--color-primary);
+  background: rgba(74, 144, 217, 0.08);
+}
 </style>

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -1,0 +1,39 @@
+import { ref, watchEffect } from 'vue'
+
+type Theme = 'light' | 'dark'
+
+const STORAGE_KEY = 'vue-crud-theme'
+
+const theme = ref<Theme>(loadTheme())
+
+function loadTheme(): Theme {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored === 'dark' || stored === 'light') {
+      return stored
+    }
+  } catch {
+    // localStorage unavailable
+  }
+  return 'light'
+}
+
+watchEffect(() => {
+  document.documentElement.setAttribute('data-theme', theme.value)
+  try {
+    localStorage.setItem(STORAGE_KEY, theme.value)
+  } catch {
+    // localStorage unavailable
+  }
+})
+
+function toggleTheme(): void {
+  theme.value = theme.value === 'light' ? 'dark' : 'light'
+}
+
+export function useTheme() {
+  return {
+    theme,
+    toggleTheme,
+  }
+}

--- a/src/pages/BookingCalendarPage.vue
+++ b/src/pages/BookingCalendarPage.vue
@@ -416,4 +416,57 @@ onMounted(async () => {
     min-width: 700px;
   }
 }
+
+[data-theme="dark"] .booking-calendar__select,
+[data-theme="dark"] .booking-calendar__input {
+  color: var(--color-text);
+  background: rgba(26, 29, 35, 0.92);
+  border-color: var(--color-border);
+}
+
+[data-theme="dark"] .booking-calendar__head,
+[data-theme="dark"] .booking-calendar__time,
+[data-theme="dark"] .booking-calendar__cell {
+  border-color: var(--color-border);
+}
+
+[data-theme="dark"] .booking-calendar__head {
+  background: rgba(26, 29, 35, 0.96);
+}
+
+[data-theme="dark"] .booking-calendar__head--time,
+[data-theme="dark"] .booking-calendar__time {
+  background: rgba(34, 38, 46, 0.98);
+}
+
+[data-theme="dark"] .booking-calendar__head--time {
+  background: rgba(26, 29, 35, 0.98);
+}
+
+[data-theme="dark"] .booking-calendar__cell {
+  background: rgba(34, 38, 46, 0.9);
+}
+
+[data-theme="dark"] .booking-calendar__cell--available .booking-calendar__cell-label {
+  color: #7edba4;
+  background: rgba(60, 196, 116, 0.16);
+}
+
+[data-theme="dark"] .booking-calendar__cell--occupied {
+  background: rgba(156, 163, 175, 0.1);
+}
+
+[data-theme="dark"] .booking-calendar__cell--occupied .booking-calendar__cell-label {
+  color: #9ca3af;
+  background: rgba(156, 163, 175, 0.15);
+}
+
+[data-theme="dark"] .booking-calendar__cell--closed {
+  background: rgba(26, 29, 35, 0.5);
+}
+
+[data-theme="dark"] .booking-calendar__cell--closed .booking-calendar__cell-label {
+  color: var(--color-text-muted);
+  background: rgba(156, 163, 175, 0.1);
+}
 </style>

--- a/src/pages/BookingListPage.vue
+++ b/src/pages/BookingListPage.vue
@@ -271,4 +271,20 @@ onMounted(async () => {
     justify-content: center;
   }
 }
+
+[data-theme="dark"] .booking-list-page__status {
+  background: rgba(95, 160, 230, 0.14);
+  color: var(--color-primary);
+}
+
+[data-theme="dark"] .booking-list-page__status--cancelled {
+  background: rgba(233, 112, 100, 0.12);
+  color: var(--color-danger);
+}
+
+[data-theme="dark"] .shared-button--secondary {
+  color: var(--color-text);
+  background: rgba(26, 29, 35, 0.96);
+  border-color: var(--color-border);
+}
 </style>

--- a/src/style.css
+++ b/src/style.css
@@ -15,6 +15,19 @@
   --spacing-lg: 1.5rem;
 }
 
+[data-theme="dark"] {
+  --color-primary: #5fa0e6;
+  --color-primary-hover: #7ab4f0;
+  --color-danger: #e97064;
+  --color-danger-hover: #f08878;
+  --color-success: #3cc474;
+  --color-bg: #1a1d23;
+  --color-surface: #22262e;
+  --color-text: #e0e4ea;
+  --color-text-muted: #9ca3af;
+  --color-border: #363b44;
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -733,4 +746,139 @@ a {
   .app-shell {
     padding: 32px;
   }
+}
+
+/* ---------- Dark-theme overrides for hardcoded rgba values ---------- */
+
+[data-theme="dark"] #app::before {
+  background:
+    radial-gradient(circle at top left, rgba(95, 160, 230, 0.15), transparent 34%),
+    radial-gradient(circle at bottom right, rgba(60, 196, 116, 0.1), transparent 28%);
+}
+
+[data-theme="dark"] .app-shell__hero {
+  background:
+    linear-gradient(140deg, rgba(34, 38, 46, 0.96), rgba(34, 38, 46, 0.84)),
+    radial-gradient(circle at top left, rgba(95, 160, 230, 0.12), transparent 38%);
+  border-color: var(--color-border);
+  box-shadow: 0 22px 45px rgba(0, 0, 0, 0.25);
+}
+
+[data-theme="dark"] .app-shell__hero-side {
+  background: rgba(26, 29, 35, 0.9);
+  border-color: var(--color-border);
+}
+
+[data-theme="dark"] .app-shell__nav-link {
+  background: rgba(34, 38, 46, 0.82);
+}
+
+[data-theme="dark"] .app-shell__nav-link:hover {
+  border-color: rgba(95, 160, 230, 0.5);
+  box-shadow: 0 14px 24px rgba(0, 0, 0, 0.2);
+}
+
+[data-theme="dark"] .app-shell__nav-link--active {
+  border-color: rgba(95, 160, 230, 0.85);
+  background: linear-gradient(180deg, rgba(95, 160, 230, 0.14), rgba(34, 38, 46, 0.96));
+  box-shadow: 0 16px 28px rgba(95, 160, 230, 0.1);
+}
+
+[data-theme="dark"] .page-shell__header,
+[data-theme="dark"] .page-shell__panel {
+  background: rgba(34, 38, 46, 0.92);
+  border-color: var(--color-border);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.2);
+}
+
+[data-theme="dark"] .page-shell__action {
+  color: #fff;
+}
+
+[data-theme="dark"] .shared-panel--form {
+  background:
+    linear-gradient(180deg, rgba(34, 38, 46, 0.96), rgba(34, 38, 46, 0.9)),
+    radial-gradient(circle at top right, rgba(95, 160, 230, 0.08), transparent 36%);
+}
+
+[data-theme="dark"] .shared-panel--table {
+  background:
+    linear-gradient(180deg, rgba(34, 38, 46, 0.96), rgba(26, 29, 35, 0.94)),
+    linear-gradient(135deg, rgba(60, 196, 116, 0.04), transparent 50%);
+}
+
+[data-theme="dark"] .shared-control,
+[data-theme="dark"] .shared-textarea {
+  color: var(--color-text);
+  background: rgba(26, 29, 35, 0.98);
+  border-color: var(--color-border);
+}
+
+[data-theme="dark"] .shared-control:focus,
+[data-theme="dark"] .shared-textarea:focus {
+  border-color: rgba(95, 160, 230, 0.9);
+  box-shadow: 0 0 0 3px rgba(95, 160, 230, 0.14);
+}
+
+[data-theme="dark"] .shared-control--error,
+[data-theme="dark"] .shared-textarea--error {
+  border-color: rgba(233, 112, 100, 0.78);
+}
+
+[data-theme="dark"] .shared-feedback--error {
+  color: #f0a09a;
+  background: rgba(233, 112, 100, 0.12);
+  border-color: rgba(233, 112, 100, 0.24);
+}
+
+[data-theme="dark"] .shared-feedback--success {
+  color: #7edba4;
+  background: rgba(60, 196, 116, 0.12);
+  border-color: rgba(60, 196, 116, 0.24);
+}
+
+[data-theme="dark"] .shared-feedback--info {
+  color: #8fc1ee;
+  background: rgba(95, 160, 230, 0.12);
+  border-color: rgba(95, 160, 230, 0.22);
+}
+
+[data-theme="dark"] .shared-empty-state {
+  background: rgba(26, 29, 35, 0.86);
+  border-color: rgba(156, 163, 175, 0.3);
+}
+
+[data-theme="dark"] .shared-list__item {
+  background: rgba(34, 38, 46, 0.9);
+  border-color: var(--color-border);
+}
+
+[data-theme="dark"] .shared-list__detail {
+  background: rgba(26, 29, 35, 0.9);
+}
+
+[data-theme="dark"] .shared-button--danger {
+  color: var(--color-danger);
+  background: rgba(233, 112, 100, 0.08);
+  border-color: rgba(233, 112, 100, 0.24);
+}
+
+[data-theme="dark"] .shared-button--danger:hover:enabled {
+  background: rgba(233, 112, 100, 0.14);
+}
+
+[data-theme="dark"] .shared-dialog__backdrop {
+  background: rgba(0, 0, 0, 0.55);
+}
+
+[data-theme="dark"] .shared-dialog__panel {
+  background: rgba(34, 38, 46, 0.98);
+  border-color: var(--color-border);
+  box-shadow: 0 22px 45px rgba(0, 0, 0, 0.35);
+}
+
+[data-theme="dark"] .shared-dialog__button--secondary {
+  color: var(--color-text);
+  background: rgba(26, 29, 35, 0.96);
+  border-color: var(--color-border);
 }


### PR DESCRIPTION
## Summary

This PR was generated automatically by AI Worker for issue #31.

### Plan

The plan covers 6 files (1 new, 5 edited) across three layers:

1. **Composable** (`useTheme.ts`) — singleton reactive state with localStorage + DOM side-effect via `watchEffect`
2. **CSS** (`style.css` + 2 page components) — `[data-theme="dark"]` overrides for all custom properties and hardcoded rgba values
3. **UI** (`App.vue` + `index.html`) — toggle button in hero-side panel + flash-prevention inline script

### Codex Output (stdout)

```
Everything looks correct. Here's a summary of what was implemented:

**Files created (1):**
- `src/composables/useTheme.ts` — singleton composable with reactive `theme` ref, `localStorage` persistence, and `watchEffect` to sync `data-theme` attribute on `<html>`

**Files edited (5):**
- `index.html` — inline script before `#app` to apply saved theme immediately, preventing flash of wrong theme
- `src/style.css` — `[data-theme="dark"]` block overriding all CSS custom properties + dark variants for every hardcoded `rgba()` background/color in global styles
- `src/App.vue` — imported `useTheme`, added toggle button in hero-side panel with accessible aria-label
- `src/pages/BookingCalendarPage.vue` — dark overrides for calendar table cells, headers, and status colors
- `src/pages/BookingListPage.vue` — dark overrides for booking status badges and secondary buttons

```

Closes #31
